### PR TITLE
Fix API usage for Valetudo version >= 0.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -572,7 +572,7 @@ class ValetudoXiaomiVacuum {
         this.log.debug(`Executing update, forced: ${forced}`);
         this.status_callbacks.push(callback);
 
-        this.sendJSONRequest('http://' + this.ip + '/api/current_status')
+        this.sendJSONRequest('http://' + this.ip + '/api/state')
             .then((response) => {
                 this.log.debug('Done executing update');
                 this.current_status = response;


### PR DESCRIPTION
With Valetudo version 0.6.0 and higher the HTTP API was changed.

Specifically: API changed from **/api/current_status** to **/api/state**